### PR TITLE
🔧 Update GitHub Actions workflow to trigger on pushes to `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Added `push` event trigger for the GitHub Actions workflow to build on commits to the `main` branch and adjusted `pull_request` syntax.