### PR TITLE
🥖 Update POM descriptions and license URLs in build files

### DIFF
--- a/techdebt-annotations/build.gradle.kts
+++ b/techdebt-annotations/build.gradle.kts
@@ -33,12 +33,12 @@ mavenPublishing {
 
     pom {
         name.set("tech-debt annotations")
-        description.set("Annotations for the tech-debt KSP tool.")
+        description.set("A KSP annotation to mark code as tech debt")
         url.set("https://github.com/igorescodro/tech-debt")
         licenses {
             license {
                 name.set("The Apache Software License, Version 2.0")
-                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                url.set("https://raw.githubusercontent.com/igorescodro/tech-debt/refs/heads/main/LICENSE")
             }
         }
         developers {

--- a/techdebt-processor/build.gradle.kts
+++ b/techdebt-processor/build.gradle.kts
@@ -35,12 +35,12 @@ mavenPublishing {
 
     pom {
         name.set("tech-debt processor")
-        description.set("KSP symbol processor for the tech-debt tool.")
+        description.set("A KSP processor to generate a tech debt report")
         url.set("https://github.com/igorescodro/tech-debt")
         licenses {
             license {
                 name.set("The Apache Software License, Version 2.0")
-                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                url.set("https://raw.githubusercontent.com/igorescodro/tech-debt/refs/heads/main/LICENSE")
             }
         }
         developers {


### PR DESCRIPTION
Revised project descriptions to clarify usage of the `tech-debt` annotations and processor. Updated license URLs to point to the project's GitHub repository.