### PR TITLE
﹫ Add detailed KDoc for `TechDebt` annotation and `Priority` enum

### DIFF
--- a/techdebt-annotations/src/commonMain/kotlin/com/escodro/techdebt/TechDebt.kt
+++ b/techdebt-annotations/src/commonMain/kotlin/com/escodro/techdebt/TechDebt.kt
@@ -1,5 +1,12 @@
 package com.escodro.techdebt
 
+/**
+ * Annotation used to mark technical debt in the codebase.
+ *
+ * @property description a brief description of the technical debt
+ * @property ticket a link or reference to the ticket tracking this technical debt
+ * @property priority the priority of the technical debt
+ */
 @Target(
     AnnotationTarget.CLASS,
     AnnotationTarget.FUNCTION,
@@ -7,14 +14,22 @@ package com.escodro.techdebt
 )
 @Retention(AnnotationRetention.SOURCE)
 annotation class TechDebt(
-    val ticket: String = "",
     val description: String = "",
+    val ticket: String = "",
     val priority: Priority = Priority.NONE
 )
 
+/** Represents the priority of the technical debt. */
 enum class Priority {
+    /** No priority assigned. */
     NONE,
+
+    /** Low-priority technical debt. */
     LOW,
+
+    /** Medium priority technical debt. */
     MEDIUM,
+
+    /** High-priority technical debt. */
     HIGH,
 }


### PR DESCRIPTION
Enhanced documentation with KDoc to describe the purpose and properties of the `TechDebt` annotation and its `Priority` levels.