### PR TITLE
🔄 Update Gradle Wrapper and dependencies to latest versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 techdebt = "0.1.0-beta01"
-kotlin = "2.0.21"
+kotlin = "2.3.0"
 kotlinx-html = "0.11.0"
 junit = "5.10.1"
 junit-platform = "1.10.1"
 
-ksp = "2.0.21-1.0.27"
+ksp = "2.3.4"
 maven-publish = "0.35.0"
 detekt = "1.23.4"
 ktfmt = "0.16.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Upgraded Gradle Wrapper to version 9.2.1 and updated Kotlin to 2.3.0, along with other dependency version increments in `libs.versions.toml` for improved compatibility and reliability.